### PR TITLE
(refactor) Bound all uses of the Error trait with 'static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,11 @@
 
 //! A generic, extendable Error type.
 
-use std::any::{Any, AnyRefExt};
 use std::fmt::{Show, Formatter, FormatError};
 use std::{raw, mem};
 use std::intrinsics::TypeId;
 
-pub trait Error: Show + Any + Send + ErrorPrivate {
+pub trait Error: Show + Send + ErrorPrivate {
     fn name(&self) -> &'static str;
 
     fn description(&self) -> Option<&str> { None }


### PR DESCRIPTION
Any struct which wants to support `cause` will need to contain
a `Box<Error>`, however, since `Error` is not bounded by `'static'`
this is impossible, and the struct needs to store `Box<Error + Send>`.

This changes rust-error to use this type internally, so as to discourage
use of `Box<Error>` without the `Send` bound.

[Fixes #2] - thanks to @andrew-d for reporting.
