### PR TITLE
Move license declaration to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "error"
 version = "0.0.1"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
+license = "MIT"
 
 [lib]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![license = "MIT"]
 //#![deny(missing_doc)]
 #![deny(warnings)]
 #![feature(macro_rules)]


### PR DESCRIPTION
`license` is picked up as an unused attribute and gets rejected by
rustc because of #[deny(warning)]